### PR TITLE
parse_args: Fix invalid index panic, option seperator defaults

### DIFF
--- a/src/cli/arg.rs
+++ b/src/cli/arg.rs
@@ -57,6 +57,9 @@ bitflags! {
         /// `--<argname>=<value>`)
         const VALUE_SEP_EQUALS = (1 << 3);
         /// The argument can have no seperator for the value (ex. `--<argname><value>`)
+        /// 
+        /// Note: This will also match [`VALUE_SEP_EQUALS`](ArgOpts::VALUE_SEP_EQUALS) but
+        /// keep the equals sign in the value: `--<argument>=<value>` -> `Some("=<value>")`.
         const VALUE_SEP_NO_SPACE = (1 << 4);
         /// The argument's value is optional
         const VALUE_OPTIONAL = (1 << 5);
@@ -88,8 +91,8 @@ impl ArgOpts {
     ///
     /// If no seperator options are set assumes all except [`ArgOpts::VALUE_SEP_NO_SPACE`].
     pub(super) fn matches_value_sep(mut self, s: &str, out_sep_len: &mut Option<usize>) -> bool {
-        if !self.intersects(ArgOpts::ALL_VALUE_SEP.difference(ArgOpts::VALUE_SEP_NO_SPACE)) {
-            self |= ArgOpts::ALL_VALUE_SEP;
+        if !self.intersects(ArgOpts::ALL_VALUE_SEP) {
+            self |= ArgOpts::ALL_VALUE_SEP.difference(ArgOpts::VALUE_SEP_NO_SPACE);
         }
 
         let c = s.chars().next();

--- a/src/cli/parse_args.rs
+++ b/src/cli/parse_args.rs
@@ -102,6 +102,7 @@ impl<'a, 'b, const N: usize> ParseFrom<N> for [&ArgDef<'a, 'b>; N] {
                     } else {
                         results[def_i] = Ok(result.map(|v| vec![v]).unwrap_or_else(Vec::default));
                     }
+                    break;
                 }
             }
 
@@ -176,13 +177,13 @@ mod tests {
         let a_space = Arg::option("a").with_opts(ArgOpts::VALUE_SEP_NEXT_ARG);
         let a_equals = Arg::option("a").with_opts(ArgOpts::VALUE_SEP_EQUALS);
 
-        let [flag_single_hyphen, flag_double_hyphen, f, a_no_space, a_space, a_equals] = [
+        let [flag_single_hyphen, flag_double_hyphen, f, a_equals, a_no_space, a_space] = [
             &flag_single_hyphen,
             &flag_double_hyphen,
             &f,
+            &a_equals,
             &a_no_space,
             &a_space,
-            &a_equals,
         ]
         .parse_from(&mut args);
 


### PR DESCRIPTION
Oops, missed this.