### PR TITLE
Use reponse file on windows and when using gcc

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsStr;
 use std::fmt::{Display, Write};
-use std::fs;
 use std::path::{Path, PathBuf};
+use std::{env, fs};
 
 use anyhow::*;
 use cargo_toml::{Manifest, Product};
@@ -330,6 +330,16 @@ pub fn set_rustc_env(key: impl Display, value: impl Display) {
 /// Display a warning on the terminal.
 pub fn print_warning(warning: impl Display) {
     println!("cargo:warning={}", warning);
+}
+
+/// Get the out directory of a crate.
+///
+/// Panics if environment variable `OUT_DIR` is not set
+/// (ie. when called outside of a build script).
+pub fn out_dir() -> PathBuf {
+    env::var_os("OUT_DIR")
+        .expect("`OUT_DIR` env variable not set (maybe called outside of build script)")
+        .into()
 }
 
 pub trait IntoWarning {

--- a/src/cli/separate_args.rs
+++ b/src/cli/separate_args.rs
@@ -155,6 +155,8 @@ impl<'a> Iterator for WindowsCommandArgs<'a> {
 }
 
 pub use shlex::Shlex as UnixCommandArgs;
+pub use shlex::join as join_unix_args;
+pub use shlex::quote as quote_unix_arg;
 
 #[cfg(windows)]
 pub type NativeCommandArgs<'a> = WindowsCommandArgs<'a>;


### PR DESCRIPTION
This is to circumvent the command-line length limitation on windows.

Export `shlex::join` as `join_unix_args`
Export `shlex::quote` as `quote_unix_arg`
Change `LinkArgsBuilder::build` to return a `Result<LinkArgs>`
Add `cargo::out_dir`