### PR TITLE
Decouple CfgArgs from kconfig; clippy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cargo-pio", "ldproxy"]
 
 [package]
 name = "embuild"
-version = "0.23.5"
+version = "0.24.0"
 authors = ["Ivan Markov <ivan.markov@gmail.com>", "Dominik Gschwind <dominik.gschwind99@gmail.com>"]
 edition = "2018"
 categories = ["embedded", "development-tools::build-utils"]

--- a/cargo-pio/Cargo.toml
+++ b/cargo-pio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-pio"
-version = "0.23.6"
+version = "0.24.0"
 edition = "2018"
 authors = ["Ivan Markov <ivan.markov@gmail.com>", "Dominik Gschwind <dominik.gschwind99@gmail.com>"]
 categories = ["embedded", "development-tools::cargo-plugins"]
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-embuild = { version = "0.23.5", path = ".." }
+embuild = { version = "0.24", path = ".." }
 anyhow = {version = "1", features = ["backtrace"]}
 log = "0.4"
 env_logger = "0.8"

--- a/ldproxy/Cargo.toml
+++ b/ldproxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ldproxy"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2018"
 authors = ["Ivan Markov <ivan.markov@gmail.com>", "Dominik Gschwind <dominik.gschwind99@gmail.com>"]
 categories = ["embedded", "command-line-utilities"]
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-embuild = { version = "0.23.5", path = ".." }
+embuild = { version = "0.24", path = ".." }
 anyhow = {version = "1", features = ["backtrace"]}
 log = "0.4"
 env_logger = "0.8"

--- a/ldproxy/src/main.rs
+++ b/ldproxy/src/main.rs
@@ -131,18 +131,18 @@ fn args() -> Result<Vec<String>> {
         // https://gcc.gnu.org/onlinedocs/gcc-11.2.0/gcc/Overall-Options.html)
         //
         // Deal with that
-        if let Some(arg) = arg.strip_prefix('@') {
-            let rsp_file = Path::new(arg);
+        if let Some(rsp_file_str) = arg.strip_prefix('@') {
+            let rsp_file = Path::new(rsp_file_str);
             // get all arguments from the response file if it exists
             if rsp_file.exists() {
                 let contents = std::fs::read_to_string(rsp_file)?;
-                debug!("Contents of {}: {}", arg, contents);
+                debug!("Contents of {}: {}", rsp_file_str, contents);
 
                 result.extend(UnixCommandArgs::new(&contents));
             }
             // otherwise just add the argument as normal
             else {
-                result.push(arg.to_owned());
+                result.push(arg);
             }
         } else {
             result.push(arg);

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -22,10 +22,7 @@ impl Factory {
     pub fn from_scons_vars(scons_vars: &pio::project::SconsVariables) -> Result<Self> {
         let clang_args = cli::NativeCommandArgs::new(&scons_vars.incflags)
             .chain(cli::NativeCommandArgs::new(
-                scons_vars
-                    .clangargs
-                    .as_deref()
-                    .unwrap_or_default(),
+                scons_vars.clangargs.as_deref().unwrap_or_default(),
             ))
             .collect();
 
@@ -103,7 +100,6 @@ impl Factory {
             .layout_tests(false)
             .rustfmt_bindings(false)
             .derive_default(true)
-            //.ctypes_prefix(c_types)
             .clang_arg("-D__bindgen")
             .clang_args(sysroot_args)
             .clang_args(&["-x", if cpp { "c++" } else { "c" }])
@@ -119,12 +115,13 @@ impl Factory {
     }
 }
 
-pub fn run(builder: bindgen::Builder) -> Result<()> {
+pub fn run(builder: bindgen::Builder) -> Result<PathBuf> {
     let output_file = PathBuf::from(env::var("OUT_DIR")?).join("bindings.rs");
     run_for_file(builder, &output_file)?;
 
     cargo::set_rustc_env(VAR_BINDINGS_FILE, output_file.try_to_str()?);
-    Ok(())
+
+    Ok(output_file)
 }
 
 pub fn run_for_file(builder: bindgen::Builder, output_file: impl AsRef<Path>) -> Result<()> {

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -318,7 +318,11 @@ pub fn set_rustc_cfg(key: impl Display, value: impl AsRef<str>) {
     if value.as_ref().is_empty() {
         println!("cargo:rustc-cfg={}", key);
     } else {
-        println!("cargo:rustc-cfg={}={}", key, value.as_ref());
+        println!(
+            "cargo:rustc-cfg={}=\"{}\"",
+            key,
+            value.as_ref().replace("\"", "\\\"")
+        );
     }
 }
 

--- a/src/cli/separate_args.rs
+++ b/src/cli/separate_args.rs
@@ -154,9 +154,9 @@ impl<'a> Iterator for WindowsCommandArgs<'a> {
     }
 }
 
-pub use shlex::Shlex as UnixCommandArgs;
 pub use shlex::join as join_unix_args;
 pub use shlex::quote as quote_unix_arg;
+pub use shlex::Shlex as UnixCommandArgs;
 
 #[cfg(windows)]
 pub type NativeCommandArgs<'a> = WindowsCommandArgs<'a>;

--- a/src/cmake.rs
+++ b/src/cmake.rs
@@ -89,14 +89,15 @@ impl TryFrom<&codemodel::target::CompileGroup> for CInclArgs {
     type Error = Error;
 
     fn try_from(value: &codemodel::target::CompileGroup) -> Result<Self, Self::Error> {
-        let flags = value
+        let args = value
             .defines
             .iter()
             .map(|d| format!("-D{}", d.define))
             .chain(value.includes.iter().map(|i| format!("\"-I{}\"", i.path)))
             .collect::<Vec<_>>()
             .join(" ");
-        Ok(Self(flags))
+
+        Ok(Self { args })
     }
 }
 

--- a/src/cmake/file_api/index.rs
+++ b/src/cmake/file_api/index.rs
@@ -285,21 +285,21 @@ impl Replies {
     }
 
     /// Load the codemodel object from a codemodel reply.
-    /// 
+    ///
     /// Convenience function for `get_kind(ObjKind::Codemodel)?.codemodel()`.
     pub fn get_codemodel(&self) -> Result<Codemodel> {
         self.get_kind(ObjKind::Codemodel)?.codemodel()
     }
 
     /// Load the cache object from a cache reply.
-    /// 
+    ///
     /// Convenience function for `get_kind(ObjKind::Cache)?.cache()`.
     pub fn get_cache(&self) -> Result<Cache> {
         self.get_kind(ObjKind::Cache)?.cache()
     }
 
     /// Load the toolchains object from a toolchains reply.
-    /// 
+    ///
     /// Convenience function for `get_kind(ObjKind::Toolchains)?.toolchains()`.
     pub fn get_toolchains(&self) -> Result<Toolchains> {
         self.get_kind(ObjKind::Toolchains)?.toolchains()

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -9,7 +9,7 @@ pub use remove_dir_all::*;
 
 /// Copy `src_file` to `dest_file_or_dir` if `src_file` is different or the destination
 /// file doesn't exist.
-/// 
+///
 /// ### Panics
 /// If `src_file` is not a file this function will panic.
 pub fn copy_file_if_different(
@@ -21,7 +21,7 @@ pub fn copy_file_if_different(
 
     assert!(src_file.is_file());
 
-    let mut src_fd = fs::File::open(src_file)?;
+    let src_fd = fs::File::open(src_file)?;
 
     let (dest_fd, dest_file) = if dest_file_or_dir.exists() {
         if dest_file_or_dir.is_dir() {
@@ -41,8 +41,8 @@ pub fn copy_file_if_different(
         (None, dest_file_or_dir.to_owned())
     };
 
-    if let Some(mut dest_fd) = dest_fd {
-        if !is_file_eq(&mut src_fd, &mut dest_fd)? {
+    if let Some(dest_fd) = dest_fd {
+        if !is_file_eq(&src_fd, &dest_fd)? {
             drop(dest_fd);
             drop(src_fd);
             fs::copy(src_file, dest_file)?;
@@ -63,7 +63,7 @@ pub fn is_file_eq(file: &File, other: &File) -> Result<bool> {
         let mut other_bytes = io::BufReader::new(&*other).bytes();
 
         // TODO: check performance
-        let result = loop {
+        loop {
             match (file_bytes.next(), other_bytes.next()) {
                 (Some(Ok(b0)), Some(Ok(b1))) => {
                     if b0 != b1 {
@@ -74,9 +74,7 @@ pub fn is_file_eq(file: &File, other: &File) -> Result<bool> {
                 (None, Some(_)) | (Some(_), None) => break Ok(false),
                 (Some(Err(e)), _) | (_, Some(Err(e))) => return Err(e.into()),
             }
-        };
-
-        result
+        }
     } else {
         Ok(false)
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -21,7 +21,7 @@ pub struct Repository {
 
 impl Repository {
     /// Create a logical repository from the git worktree `dir`.
-    /// 
+    ///
     /// Note the git dir must be `.git`.
     pub fn new(dir: impl AsRef<Path>) -> Repository {
         Repository {
@@ -248,7 +248,7 @@ pub enum Ref {
     Commit(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CloneOptions {
     /// Force the working directory to be this specific tag, branch or commit.
     ///
@@ -275,17 +275,6 @@ pub struct CloneOptions {
     /// Note that this option is ignored when [`force_ref`](Self::force_ref) specifies a
     /// commit.
     pub depth: Option<NonZeroU64>,
-}
-
-impl Default for CloneOptions {
-    fn default() -> Self {
-        Self {
-            force_ref: None,
-            branch_update_action: None,
-            force_clean: false,
-            depth: None,
-        }
-    }
 }
 
 impl CloneOptions {
@@ -328,7 +317,7 @@ impl CloneOptions {
     }
 
     /// The depth that should be cloned, if `None` the full repository is cloned.
-    /// 
+    ///
     /// `depth` must be greater than zero or else this method will panic.
     ///
     /// Note that this option is ignored when [`force_ref`](Self::force_ref) specifies a

--- a/src/kconfig.rs
+++ b/src/kconfig.rs
@@ -2,19 +2,12 @@
 /// the ESP-IDF one.
 use std::{
     collections::HashMap,
-    convert::TryFrom,
-    env,
-    fmt::Display,
     fs,
-    io::{self, BufRead},
+    io::{self, BufRead, Read},
     path::Path,
 };
 
 use anyhow::*;
-
-use crate::cargo;
-
-const VAR_CFG_ARGS_KEY: &str = "EMBUILD_CFG_ARGS";
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum Tristate {
@@ -31,25 +24,66 @@ pub enum Value {
 }
 
 impl Value {
-    fn parse(str: impl AsRef<str>) -> Option<Self> {
-        let str = str.as_ref();
-
-        Some(if str.starts_with('\"') {
-            Self::String(str.to_owned()) // TODO: Properly parse and escape
-        } else if str == "y" {
-            Self::Tristate(Tristate::True)
-        } else if str == "n" {
-            Self::Tristate(Tristate::False)
-        } else if str == "m" {
-            Self::Tristate(Tristate::Module)
-        } else {
-            return None;
+    pub fn to_rustc_cfg(&self, prefix: impl AsRef<str>, key: impl AsRef<str>) -> Option<String> {
+        match self {
+            Value::Tristate(Tristate::True) => Some(""),
+            Value::String(s) => Some(s.as_str()),
+            _ => None,
+        }
+        .map(|value| {
+            if value.is_empty() {
+                format!(
+                    "{}_{}",
+                    prefix.as_ref().to_lowercase(),
+                    key.as_ref().to_lowercase()
+                )
+            } else {
+                format!(
+                    "{}_{}=\"{}\"",
+                    prefix.as_ref().to_lowercase(),
+                    key.as_ref().to_lowercase(),
+                    value.replace("\"", "\\\"")
+                )
+            }
         })
     }
 }
 
-pub fn load(path: impl AsRef<Path>) -> Result<impl Iterator<Item = (String, Value)>> {
-    Ok(io::BufReader::new(fs::File::open(path.as_ref())?)
+/// Try to load the configurations from a generated kconfig json file.
+pub fn try_from_json_file(path: impl AsRef<Path>) -> Result<impl Iterator<Item = (String, Value)>> {
+    try_from_json(fs::File::open(path)?)
+}
+
+/// Try to load the configurations from a generated kconfig json stream.
+pub fn try_from_json<R>(reader: R) -> Result<impl Iterator<Item = (String, Value)>>
+where
+    R: Read,
+{
+    let values: HashMap<String, serde_json::Value> = serde_json::from_reader(reader)?;
+
+    let iter = values.into_iter().filter_map(|(k, v)| match v {
+        serde_json::Value::Bool(true) => Some((k, Value::Tristate(Tristate::True))),
+        serde_json::Value::Bool(false) => Some((k, Value::Tristate(Tristate::False))),
+        serde_json::Value::String(value) => Some((k, Value::String(value))),
+        _ => None,
+    });
+
+    Ok(iter)
+}
+
+/// Try to load the configurations from a generated .config file.
+pub fn try_from_config_file(
+    path: impl AsRef<Path>,
+) -> Result<impl Iterator<Item = (String, Value)>> {
+    try_from_config(fs::File::open(path.as_ref())?)
+}
+
+/// Try to load the configurations from a generated .config stream.
+pub fn try_from_config<R>(reader: R) -> Result<impl Iterator<Item = (String, Value)>>
+where
+    R: Read,
+{
+    let iter = io::BufReader::new(reader)
         .lines()
         .filter_map(|line| line.ok().map(|l| l.trim().to_owned()))
         .filter(|line| !line.starts_with('#'))
@@ -60,97 +94,28 @@ pub fn load(path: impl AsRef<Path>) -> Result<impl Iterator<Item = (String, Valu
                 split
                     .next()
                     .map(|v| v.trim())
-                    .map(Value::parse)
-                    .flatten()
+                    .and_then(parse_config_value)
                     .map(|value| (key.to_owned(), value))
             } else {
                 None
             }
-        }))
+        });
+
+    Ok(iter)
 }
 
-#[derive(Clone, Debug)]
-pub struct CfgArgs(Vec<(String, Value)>);
+fn parse_config_value(str: impl AsRef<str>) -> Option<Value> {
+    let str = str.as_ref();
 
-impl TryFrom<&Path> for CfgArgs {
-    type Error = anyhow::Error;
-
-    fn try_from(path: &Path) -> Result<Self> {
-        Ok(Self(load(path)?.collect()))
-    }
-}
-
-impl CfgArgs {
-    /// Try to load the configurations from a generated kconfig json file.
-    pub fn try_from_json(path: impl AsRef<Path>) -> Result<Self> {
-        let values: HashMap<String, serde_json::Value> =
-            serde_json::from_reader(fs::File::open(path)?)?;
-
-        let cfgs = values
-            .into_iter()
-            .filter_map(|(k, v)| match v {
-                serde_json::Value::Bool(true) => Some((k, Value::Tristate(Tristate::True))),
-                serde_json::Value::Bool(false) => Some((k, Value::Tristate(Tristate::False))),
-                serde_json::Value::String(value) => Some((k, Value::String(value))),
-                _ => None,
-            })
-            .collect();
-
-        Ok(CfgArgs(cfgs))
-    }
-
-    /// Add configuration options from the parsed kconfig output file.
-    ///
-    /// All options will consist of `<prefix>_<option name>` where both the prefix and the option name are
-    /// automatically lowercased.
-    ///
-    /// They can be used in conditional compilation using the `#[cfg()]` attribute or the
-    /// `cfg!()` macro (ex. `cfg!(<prefix>_<kconfig option>)`).
-    pub fn output(&self, prefix: impl AsRef<str>) {
-        for arg in self.gather(prefix) {
-            cargo::set_rustc_cfg(arg, "");
-        }
-    }
-
-    /// Propagate all configuration options to all dependents of this crate.
-    ///
-    /// All options will consist of `<prefix>_<option name>` where the option name is
-    /// automatically lowercased.
-    ///
-    /// ### **Important**
-    /// Calling this method in a dependency doesn't do anything on itself. All dependents
-    /// that want to have these options propagated must call
-    /// [`CfgArgs::output_propagated`] in their build script with the value of this
-    /// crate's `links` property (specified in `Cargo.toml`).
-    pub fn propagate(&self, prefix: impl AsRef<str>) {
-        let args = self.gather(prefix);
-
-        cargo::set_metadata(VAR_CFG_ARGS_KEY, args.join(":"));
-    }
-
-    /// Add options from `lib_name` which have been propagated using [`propagate`](CfgArgs::propagate).
-    ///
-    /// `lib_name` doesn't refer to a crate, library or package name, it refers to a
-    /// dependency's `links` property value, which is specified in its package manifest
-    /// (`Cargo.toml`).
-    pub fn output_propagated(lib_name: impl Display) -> Result<()> {
-        for arg in env::var(format!("DEP_{}_{}", lib_name, VAR_CFG_ARGS_KEY))?.split(':') {
-            cargo::set_rustc_cfg(arg, "");
-        }
-        Ok(())
-    }
-
-    pub fn gather(&self, prefix: impl AsRef<str>) -> Vec<String> {
-        self.0
-            .iter()
-            .filter_map(|(key, value)| match value {
-                Value::Tristate(Tristate::True) => Some(format!(
-                    "{}_{}",
-                    prefix.as_ref().to_lowercase(),
-                    key.to_lowercase()
-                )),
-                _ => None,
-            })
-            .collect()
-    }
+    Some(if str.starts_with('\"') {
+        Value::String(str[1..str.len() - 1].to_owned())
+    } else if str == "y" {
+        Value::Tristate(Tristate::True)
+    } else if str == "n" {
+        Value::Tristate(Tristate::False)
+    } else if str == "m" {
+        Value::Tristate(Tristate::Module)
+    } else {
+        return None;
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,14 @@ pub mod bingen;
 pub mod build;
 pub mod cargo;
 pub mod cli;
+pub mod cmake;
+pub mod fs;
+pub mod git;
 pub mod kconfig;
 pub mod pio;
 pub mod python;
 pub mod symgen;
 pub mod utils;
-pub mod git;
-pub mod fs;
-pub mod cmake;
 
 pub use which;
 

--- a/src/pio.rs
+++ b/src/pio.rs
@@ -1174,10 +1174,8 @@ impl Resolver {
         } else if mcu.starts_with("stm32g0")
             || mcu.starts_with("stm32l0")
             || mcu.starts_with("stm32f0")
+            || mcu.starts_with("nrf51")
         {
-            // ARM Cortex-M0/M0+
-            "thumbv6m-none-eabi"
-        } else if mcu.starts_with("nrf51") {
             // ARM Cortex-M0/M0+
             "thumbv6m-none-eabi"
         } else if mcu.starts_with("nrf52") {

--- a/src/pio/project.rs
+++ b/src/pio/project.rs
@@ -489,7 +489,9 @@ impl TryFrom<&SconsVariables> for build::CInclArgs {
     type Error = anyhow::Error;
 
     fn try_from(scons: &SconsVariables) -> Result<Self> {
-        Ok(Self(scons.incflags.clone()))
+        Ok(Self {
+            args: scons.incflags.clone(),
+        })
     }
 }
 


### PR DESCRIPTION
@N3xed:
- Lots of small changes due to running the code base through `clippy` - apologies for that
- The important ones are in `kconfig.rs` and `build.rs`:
  -  Basically, I had to decouple the notion of `kconfig` values from the notion of `rustc` cfgs (`CfgArgs`), because some of the configurations for `rustc` might not come from `kconfig` (case in point: the ESP IDF version which is coming to `esp-idf-sys`), or might be a variation of a `kconfig` value for easier use within Rust code (case in point: the `esp32`, `esp32s2`, `esp32s3` boolean configs, which are derived from the `CONFIG_IDF_TARGET` `kconfig` string value, but are turned into booleans for shorter`#[cfg(...)]` code).
  - I think this overall makes `CfgArgs` a bit more generic and also aligned to `CInclArgs` and `LinkArgs`. I therefore moved it from `kconfig.rs` - which is now just a producer for `(String, kconfig::Value)` iterators - to `build.rs` - where the other `*Args` were.