### PR TITLE
espidf: Improve msys workaround

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cargo-pio", "ldproxy"]
 
 [package]
 name = "embuild"
-version = "0.25.0"
+version = "0.25.1"
 authors = ["Ivan Markov <ivan.markov@gmail.com>", "Dominik Gschwind <dominik.gschwind99@gmail.com>"]
 edition = "2018"
 categories = ["embedded", "development-tools::build-utils"]


### PR DESCRIPTION
Windows: Fixes compile errors when `cygpath` is in the `PATH` while not using msys or cygwin.

cc https://github.com/esp-rs/esp-idf-sys/issues/23