### PR TITLE
Addition of use std::result::Result::Ok;

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::{env, fs};
+use std::result::Result::Ok;
 
 use anyhow::*;
 

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -2,6 +2,7 @@ use std::ffi::OsStr;
 use std::fmt::{Display, Write};
 use std::path::{Path, PathBuf};
 use std::{env, fs};
+use std::result::Result::Ok;
 
 use anyhow::*;
 use cargo_toml::{Manifest, Product};

--- a/src/pio.rs
+++ b/src/pio.rs
@@ -7,6 +7,7 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
+use std::result::Result::Ok;
 
 use anyhow::*;
 use log::*;

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,4 +1,5 @@
 use anyhow::*;
+use std::result::Result::Ok;
 
 use crate::cmd_output;
 


### PR DESCRIPTION
Not quite sure how this has been missed unless it's something weird unique to a windows setup for rust.
But I had to add the following lines for this to build
As per https://github.com/ivmarkov/embuild/issues/25
