### PR TITLE
Add features to reduce number of required dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,21 +13,38 @@ repository = "https://github.com/ivmarkov/embuild"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 
+[features]
+default = []
+
+# Platformio support
+pio = ["ureq", "bindgen", "tempfile", "which", "manifest"]
+# cmake file-api & utilities
+cmake = ["dep-cmake", "tempfile", "bindgen"]
+# glob utilities
+glob = ["globwalk"]
+# Cargo.toml manifest utilities
+manifest = ["cargo_toml"]
+# esp-idf installer
+espidf = ["tempfile", "which", "git"]
+# git utilities
+git = ["remove_dir_all"]
+
 [dependencies]
-which = "4.1"
-tempfile = "3.2"
-globwalk = "0.8"
-anyhow = {version = "1", features = ["backtrace"]}
+anyhow = { version = "1", features = ["backtrace"] }
 log = "0.4"
-serde = {version = "1", features = ["derive"]}
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-ureq = "2.1"
 toml = "0.5"
-cargo_toml = "0.9"
-bindgen = "0.59.2"
 xmas-elf = "0.8"
 bitflags = "1.3"
 shlex = "1.0"
-remove_dir_all = "0.7"
-cmake = "0.1"
 dirs = "4.0"
+
+remove_dir_all = { version = "0.7", optional = true }
+cargo_toml = { version = "0.9", optional = true }
+which = { version = "4.1", optional = true }
+globwalk = { version = "0.8", optional = true }
+tempfile = { version = "3.2", optional = true }
+ureq = { version = "2.1", optional = true }
+bindgen = { version = "0.59.2", optional = true }
+dep-cmake = { package = "cmake", version = "0.1", optional = true }

--- a/cargo-pio/Cargo.toml
+++ b/cargo-pio/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-embuild = { version = "0.26", path = ".." }
+embuild = { version = "0.26", path = "..", features = ["pio"] }
 anyhow = {version = "1", features = ["backtrace"]}
 log = "0.4"
 env_logger = "0.8"

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -5,7 +5,7 @@ use std::{env, fs};
 use anyhow::{anyhow, bail, Context, Error, Result};
 
 use crate::utils::OsStrExt;
-use crate::{cargo, cli, cmake, cmd, cmd_output, pio};
+use crate::{cargo, cmd, cmd_output};
 
 pub const VAR_BINDINGS_FILE: &str = "EMBUILD_GENERATED_BINDINGS_FILE";
 
@@ -19,7 +19,9 @@ pub struct Factory {
 }
 
 impl Factory {
-    pub fn from_scons_vars(scons_vars: &pio::project::SconsVariables) -> Result<Self> {
+    #[cfg(feature = "pio")]
+    pub fn from_scons_vars(scons_vars: &crate::pio::project::SconsVariables) -> Result<Self> {
+        use crate::cli;
         let clang_args = cli::NativeCommandArgs::new(&scons_vars.incflags)
             .chain(cli::NativeCommandArgs::new(
                 scons_vars.clangargs.as_deref().unwrap_or_default(),
@@ -35,8 +37,9 @@ impl Factory {
         })
     }
 
+    #[cfg(feature = "cmake")]
     pub fn from_cmake(
-        compile_group: &cmake::file_api::codemodel::target::CompileGroup,
+        compile_group: &crate::cmake::file_api::codemodel::target::CompileGroup,
     ) -> Result<Self> {
         use crate::cmake::file_api::codemodel::Language;
         assert!(

--- a/src/build.rs
+++ b/src/build.rs
@@ -34,12 +34,14 @@ pub fn env_options_iter(
         }))
 }
 
+#[cfg(feature = "glob")]
 pub fn tracked_env_globs_iter(
     env_var_prefix: impl AsRef<str>,
 ) -> Result<impl Iterator<Item = (PathBuf, PathBuf)>> {
     track_sources(env_globs_iter(env_var_prefix)?)
 }
 
+#[cfg(feature = "glob")]
 pub fn env_globs_iter(
     env_var_prefix: impl AsRef<str>,
 ) -> Result<impl Iterator<Item = (PathBuf, PathBuf)>> {
@@ -66,6 +68,7 @@ pub fn env_globs_iter(
         .flatten())
 }
 
+#[cfg(feature = "glob")]
 pub fn tracked_globs_iter(
     base: impl AsRef<Path>,
     globs: &[impl AsRef<str>],
@@ -73,6 +76,7 @@ pub fn tracked_globs_iter(
     track_sources(globs_iter(base, globs)?)
 }
 
+#[cfg(feature = "glob")]
 pub fn globs_iter(
     base: impl AsRef<Path>,
     globs: &[impl AsRef<str>],

--- a/src/cmake.rs
+++ b/src/cmake.rs
@@ -15,7 +15,7 @@ use crate::cli::NativeCommandArgs;
 use crate::cmd_output;
 
 pub mod file_api;
-pub use ::cmake::*;
+pub use ::dep_cmake::*;
 pub use file_api::Query;
 
 /// Get all variables defined in the `cmake_script_file`.

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -5,7 +5,6 @@ use std::io::{self, Read};
 use std::path::Path;
 
 use anyhow::Result;
-pub use remove_dir_all::*;
 
 /// Copy `src_file` to `dest_file_or_dir` if `src_file` is different or the destination
 /// file doesn't exist.

--- a/src/git.rs
+++ b/src/git.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 
-use crate::fs::remove_dir_all;
 use crate::utils::PathExt;
 use crate::{cmd, cmd_output};
 
@@ -207,7 +206,7 @@ impl Repository {
         };
 
         if should_remove {
-            remove_dir_all(&self.worktree)?;
+            remove_dir_all::remove_dir_all(&self.worktree)?;
         }
 
         if should_clone {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,31 @@
+#[cfg(feature = "bindgen")]
 pub mod bindgen;
+
+#[cfg(feature = "pio")]
+pub mod pio;
+
+#[cfg(feature = "cmake")]
+pub mod cmake;
+
+#[cfg(feature = "espidf")]
+pub mod espidf;
+
+#[cfg(feature = "git")]
+pub mod git;
+
 pub mod bingen;
 pub mod build;
 pub mod cargo;
 pub mod cli;
-pub mod cmake;
-pub mod espidf;
 pub mod fs;
-pub mod git;
 pub mod kconfig;
-pub mod pio;
 pub mod python;
 pub mod symgen;
 pub mod utils;
-
-pub use which;
 
 // This needs to be exported because some macros use `anyhow` and we don't want to force
 // an explicit dependency on the user.
 #[doc(hidden)]
 pub use anyhow;
+#[cfg(feature = "which")]
+pub use which;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -272,6 +272,7 @@ impl OsStrExt for Path {}
 impl OsStrExt for PathBuf {}
 
 /// Download the contents of `url` to `writer`.
+#[cfg(feature = "ureq")]
 pub fn download_file_to(url: &str, writer: &mut impl std::io::Write) -> Result<()> {
     let req = ureq::get(url).call()?;
     if req.status() != 200 {


### PR DESCRIPTION
The embuild library has a lot of utilities which almost all need specific dependencies
which are sometimes quite heavy (have a large number of sub-dependencies). Most of
the time when using embuild only a few utilities are needed resulting in much more
compiled crates than needed. This increases initial compile time and disk usage.

This change adds a number of features (disabled by default) that gives the user the option
to only enable what they need. Most of the heavy dependencies were made optional and
now only get enabled by setting the specific feature that needs them

This change does have much of an inpact on `esp-idf-*` libraries (2-5s on initial compile time max)
but for tools that don't need most of the heavy utilities the impact is great (150 (all)->58 (barebones)).

Please tell me what you think about this change.