### PR TITLE
build: add cmake for aarch64 linux into cmake.json

### DIFF
--- a/src/espidf/resources/cmake.json
+++ b/src/espidf/resources/cmake.json
@@ -49,6 +49,11 @@
                         "size": 43877847,
                         "url": "https://github.com/Kitware/CMake/releases/download/v3.20.3/cmake-3.20.3-linux-x86_64.tar.gz"
                     },
+                    "linux-arm64": {
+                        "sha256": "77620f99e9d5f39cf4a49294c6a68c89a978ecef144894618974b9958efe3c2a",
+                        "size": 45139836,
+                        "url": "https://github.com/Kitware/CMake/releases/download/v3.20.3/cmake-3.20.3-linux-aarch64.tar.gz"
+                    },
                     "linux-armel": {
                         "sha256": "f8bd050c2745f0dcc4b7cef9738bbfef775950a10f5bd377abb0062835e669dc",
                         "size": 13759084,


### PR DESCRIPTION
[remove ulp_gcc_toolchain for aarch64 linux](https://github.com/esp-rs/esp-idf-sys/pull/62)