### PR TITLE
Add win-arm64 platform support to tools schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [main] - TBD
 - Add CACHEDIR.TAG to idf and pio temporary directories, to prevent Linux backups
   from picking them up (see TODO, no support is added for MacOS/Windows).
+- Fix build on esp-idf master branch (new platform).
 
 ## [0.33.1] - 2025-07-27
 - Fix a bug where the cmake utilities refused to work with CMake 4 due to a broken version check

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -257,6 +257,7 @@ fn parse_tools(
                     ("macos", "aarch64") => info.macos_arm64.clone(),
                     ("windows", "x86") => info.win32.clone(),
                     ("windows", "x86_64") => info.win64.clone(),
+                    ("windows", "aarch64") => info.win_arm64.clone(),
                     _ => None,
                 }
             };

--- a/src/espidf/tools_schema.rs
+++ b/src/espidf/tools_schema.rs
@@ -409,6 +409,8 @@ pub(crate) enum PlatformOverrideInfoPlatformsItem {
     Win32,
     #[serde(rename = "win64")]
     Win64,
+    #[serde(rename = "win-arm64")]
+    WinArm64,
 }
 impl From<&PlatformOverrideInfoPlatformsItem> for PlatformOverrideInfoPlatformsItem {
     fn from(value: &PlatformOverrideInfoPlatformsItem) -> Self {
@@ -426,6 +428,7 @@ impl ToString for PlatformOverrideInfoPlatformsItem {
             Self::MacosArm64 => "macos-arm64".to_string(),
             Self::Win32 => "win32".to_string(),
             Self::Win64 => "win64".to_string(),
+            Self::WinArm64 => "win-arm64".to_string(),
         }
     }
 }
@@ -441,6 +444,7 @@ impl std::str::FromStr for PlatformOverrideInfoPlatformsItem {
             "macos-arm64" => Ok(Self::MacosArm64),
             "win32" => Ok(Self::Win32),
             "win64" => Ok(Self::Win64),
+            "win-arm64" => Ok(Self::WinArm64),
             _ => Err("invalid value".into()),
         }
     }
@@ -735,6 +739,8 @@ pub(crate) struct VersionInfo {
     pub(crate) win32: Option<PlatformDownloadInfo>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) win64: Option<PlatformDownloadInfo>,
+    #[serde(rename = "win-arm64", default, skip_serializing_if = "Option::is_none")]
+    pub(crate) win_arm64: Option<PlatformDownloadInfo>,
 }
 impl From<&VersionInfo> for VersionInfo {
     fn from(value: &VersionInfo) -> Self {


### PR DESCRIPTION
### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/embuild/blob/main/embuild/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
The ESP-IDF tools.json manifest added a win-arm64 platform variant for Windows ARM64. Add it to PlatformOverrideInfoPlatformsItem enum, VersionInfo struct, and the OS matcher in parse_tools to prevent panics when parsing manifests that include this platform.

#### Testing
Spotted on the idf-next CI for esp-idf-hal (https://github.com/esp-rs/esp-idf-hal/actions/runs/23682870831/job/68997591274). It's aleady a problem on `release/v6.0` (not just `master`), so probably worth having already.